### PR TITLE
Fix failing tests

### DIFF
--- a/src/wporg.test.js
+++ b/src/wporg.test.js
@@ -3,11 +3,13 @@ const wporg = require("./wporg.js");
 // getWPVersion()
 test("WP.org returns a WP version number", () => {
   expect.assertions(1);
-  return expect(wporg.getWPVersion()).resolves.toHaveLength(5);
+  return expect(wporg.getWPVersion()).resolves.toMatch(/^\d+\./);
 });
 
 // getPluginVersion()
 test("WP.org returns a WooCommerce version number", () => {
   expect.assertions(1);
-  return expect(wporg.getPluginVersion("woocommerce")).resolves.toHaveLength(5);
+  return expect(wporg.getPluginVersion("woocommerce")).resolves.toMatch(
+    /^\d+\./
+  );
 });


### PR DESCRIPTION
WP.org returns 5.1 for minor versions, rather than 5.1.0.

This PR checks the response value contains 'x.x' rather than expecting it to be five characters long.